### PR TITLE
find and fix the bug:'Bug#779717:FATAL:isolate_holder.cc(70)]Couldn't mmap v8 natives data file

### DIFF
--- a/data/debian/crosswalk.install
+++ b/data/debian/crosswalk.install
@@ -2,5 +2,6 @@ build-desktop/Release/xwalk usr/lib/xwalk
 build-desktop/Release/libffmpegsumo.so usr/lib/xwalk
 build-desktop/Release/icudtl.dat usr/lib/xwalk
 build-desktop/Release/xwalk.pak usr/lib/xwalk
-build-desktop/Release/*.bin usr/lib/xwalk
+build-desktop/Release/natives_blob.bin usr/lib/xwalk
+build-desktop/Release/snapshot_blob.bin usr/lib/xwalk
 build-desktop/Release/copyright /usr/share/doc/crosswalk

--- a/data/debian/crosswalk.install
+++ b/data/debian/crosswalk.install
@@ -2,4 +2,5 @@ build-desktop/Release/xwalk usr/lib/xwalk
 build-desktop/Release/libffmpegsumo.so usr/lib/xwalk
 build-desktop/Release/icudtl.dat usr/lib/xwalk
 build-desktop/Release/xwalk.pak usr/lib/xwalk
+build-desktop/Release/*.bin usr/lib/xwalk
 build-desktop/Release/copyright /usr/share/doc/crosswalk


### PR DESCRIPTION
Adding the following two lines to crosswalk-package-tool/data/debian/crosswalk.install fix the bug:
      build-desktop/Release/natives_blob.bin usr/lib/xwalk
     build-desktop/Release/snapshot_blob.bin usr/lib/xwalk
or
     build-desktop/Release/*.bin usr/lib/xwalk
