### PR TITLE
find and fix the bug:'Bug#779717:FATAL:isolate_holder.cc(70)]Couldn't mmap v8 natives data file 

### DIFF
--- a/data/debian/crosswalk.install
+++ b/data/debian/crosswalk.install
@@ -2,4 +2,6 @@ build-desktop/Release/xwalk usr/lib/xwalk
 build-desktop/Release/libffmpegsumo.so usr/lib/xwalk
 build-desktop/Release/icudtl.dat usr/lib/xwalk
 build-desktop/Release/xwalk.pak usr/lib/xwalk
+build-desktop/Release/natives_blob.bin usr/lib/xwalk
+build-desktop/Release/snapshot_blob.bin usr/lib/xwalk
 build-desktop/Release/copyright /usr/share/doc/crosswalk


### PR DESCRIPTION
1.Description about the bug:
After packing crosswalk project with crosswalk-package-tool, I install the .deb file of crosswalk successfully.However, when Itry to run the command of "xwalk http://www.baidu.com", the bug "Bug#779717:FATAL:isolate_holder.cc(70)] Couldn't mmap v8 natives data file" appears.
2. Analysis and Solution:
The Chromium(or xwalk ) builds its v8 code into natives_blob.bin and snapshot_blob.bin, and loading them itself at runtime instead of linking them statically to the chromium binary.
Meantime, the Crosswalk is based on the chromium content module. However,the current debian build under /crosswalk-package-tool/data/debian doesn't copy these files into /usr/lib/xwalk, hense the error.
Adding the following two lines to crosswalk-package-tool/data/debian/crosswalk.install fix the build:
Build-desktop/Release/*.bin usr/lib/xwalk

or
Build-desktop/Release/natives_blob.bin usr/lib/xwalk

Build-desktop/Release/snapshot_blob.bin usr/lib/xwalk
