### PR TITLE
Fix errors in command line after enabling Nacl support

### DIFF
--- a/data/debian/crosswalk.install
+++ b/data/debian/crosswalk.install
@@ -4,4 +4,6 @@ build-desktop/Release/icudtl.dat usr/lib/xwalk
 build-desktop/Release/xwalk.pak usr/lib/xwalk
 build-desktop/Release/natives_blob.bin usr/lib/xwalk
 build-desktop/Release/snapshot_blob.bin usr/lib/xwalk
+build-desktop/Release/nacl_irt*.nexe usr/lib/xwalk
+build-desktop/Release/nacl_helper usr/lib/xwalk
 build-desktop/Release/copyright /usr/share/doc/crosswalk


### PR DESCRIPTION
Fix issues about errors in command line which reads:
LaunchProcess: failed to execvp:
/usr/lib/xwalk/nacl_helper
[0401/131824:ERROR:nacl_fork_delegate_linux.cc(314)] Bad NaCl helper startup ack (0 bytes)
[0401/131824:ERROR:nacl_browser.cc(268)] Failed to open NaCl IRT file "/usr/lib/xwalk/nacl_irt_x86_64.nexe": -4
